### PR TITLE
Add ability to change merging behavior at runtime.

### DIFF
--- a/src/main/java/org/atteo/xmlcombiner/XmlCombiner.java
+++ b/src/main/java/org/atteo/xmlcombiner/XmlCombiner.java
@@ -84,6 +84,17 @@ public class XmlCombiner {
 		 */
 		void postProcess(Element recessive, Element dominant, Element result);
 	}
+	
+	/**
+	 * Allows to change the element merge behavior at runtime.
+	 */
+	public interface MergeFilter {
+		/**
+		 * Specify merging technique for the element.
+		 * @param element current element for which to provide the merging behavior
+		 */
+		CombineChildren query(Element element);
+	}
 
 	private final DocumentBuilder documentBuilder;
 	private final Document document;
@@ -93,7 +104,14 @@ public class XmlCombiner {
 		public void postProcess(Element recessive, Element dominant, Element result) {
 		}
 	};
+	private static final MergeFilter DEFAULT_MERGE_FILTER = new MergeFilter() {
+		@Override
+		public CombineChildren query(Element element) {
+			return CombineChildren.MERGE;
+		}
+	};
 	private Filter filter = NULL_FILTER;
+	private MergeFilter mergeFilter = DEFAULT_MERGE_FILTER;
 	private final ChildContextsMapper childContextMapper = new KeyAttributesChildContextsMapper();
 
 	public static void main(String[] args) throws ParserConfigurationException, SAXException, IOException,
@@ -175,6 +193,17 @@ public class XmlCombiner {
 			return;
 		}
 		this.filter = filter;
+	}
+	
+	/**
+	 * Sets the merging behavior filter.
+	 */
+	public void setFilter(MergeFilter mergeFilter) {
+		if (mergeFilter ==  null) {
+			this.mergeFilter = DEFAULT_MERGE_FILTER;
+			return;
+		}
+		this.mergeFilter = mergeFilter;
 	}
 
 	/**
@@ -260,7 +289,13 @@ public class XmlCombiner {
 		if (combineChildren == null) {
 			combineChildren = getCombineChildren(recessive.getElement());
 			if (combineChildren == null) {
-				combineChildren = CombineChildren.MERGE;
+				combineChildren = mergeFilter.query(dominant.getElement());
+				if (combineChildren == null) {
+					combineChildren = mergeFilter.query(recessive.getElement());
+					if (combineChildren == null) {
+						combineChildren = CombineChildren.MERGE;
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
I cannot seem to find an ability to change the merging behavior on-the-fly at runtime.
It seems cumbersome to go and modify each XML tag in the documents and create/specify the merge attribute "combine.children".

This could be implemented using a merge behavior filter. Proposing this pull for the implementation.

This is same as #4 but with working tests.
