### PR TITLE
Fix #11: combine.children='ADD'

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,45 @@ results in
 </config>
 ```
 
+Another option is to use ['add'](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineChildren.html#ADD) value for 'combine.children' attribute. When two matching elements have 'combine.children' set to 'add' (or at least one of them), both elements will appear in the final document without merging their content.
+
+For example, combining:
+
+```xml
+<config>
+    <service id='1' combine.children='ADD'>
+        <parameter>parameter</parameter>
+        <parameter2>parameter2</parameter2>
+    </service>
+</config>
+```
+
+with
+
+```xml
+<config>
+    <service id='1'>
+        <parameter>other value</parameter>
+        <parameter3>parameter3</parameter3>
+    </service>
+</config>
+```
+
+results in
+
+```xml
+<config>
+    <service id='1'>
+        <parameter>parameter</parameter>
+        <parameter2>parameter2</parameter2>
+    </service>
+    <service id='1'>
+        <parameter>other value</parameter>
+        <parameter3>parameter3</parameter3>
+    </service>
+</config>
+```
+
 In addition there is also ['combine.self'](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineSelf.html) attribute which allows to control how the element itself is combined.
 Combining
 
@@ -163,7 +202,7 @@ Below you can find the table of all allowed values which link to their detailed 
 |-----------------|-------------|
 | [merge](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineChildren.html#MERGE) (default) | [merge](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineSelf.html#MERGE) (default) |
 | [append](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineChildren.html#APPEND) | [defaults](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineSelf.html#DEFAULTS) |
-| | [overridable](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineSelf.html#OVERRIDABLE) |
+| [add](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineChildren.html#ADD) | [overridable](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineSelf.html#OVERRIDABLE) |
 | | [overridable_by_tag](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineSelf.html#OVERRIDABLE_BY_TAG) |
 | | [override](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineSelf.html#OVERRIDE) |
 | | [remove](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineSelf.html#REMOVE) | 

--- a/src/main/java/org/atteo/xmlcombiner/CombineChildren.java
+++ b/src/main/java/org/atteo/xmlcombiner/CombineChildren.java
@@ -99,7 +99,55 @@ public enum CombineChildren {
 	 * </pre>
 	 * </p>
 	 */
-	APPEND;
+	APPEND,
+
+	/**
+	 * Add both matching elements to the result without merging them.
+	 *
+	 * <p>
+	 * When two elements match (have the same key), if at least one of them has combine.children="ADD",
+	 * both elements will be added to the final document without merging their content.
+	 * This is different from MERGE (which merges matching elements) and APPEND (which appends children).
+	 * <br/>
+	 * Example:<br/>
+	 * First:
+	 * <pre>
+	 * {@code
+	 * <config>
+	 *     <service id="1" combine.children="ADD">
+	 *         <parameter>parameter</parameter>
+	 *     </service>
+	 * </config>
+	 * }
+	 * </pre>
+	 * Second:
+	 * <pre>
+	 * {@code
+	 * <config>
+	 *     <service id="1">
+	 *         <parameter>other value</parameter>
+	 *         <parameter2>parameter2</parameter2>
+	 *     </service>
+	 * </config>
+	 * }
+	 * </pre>
+	 * Result:
+	 * <pre>
+	 * {@code
+	 * <config>
+	 *     <service id="1">
+	 *         <parameter>parameter</parameter>
+	 *     </service>
+	 *     <service id="1">
+	 *         <parameter>other value</parameter>
+	 *         <parameter2>parameter2</parameter2>
+	 *     </service>
+	 * </config>
+	 * }
+	 * </pre>
+	 * </p>
+	 */
+	ADD;
 
 	public static final String ATTRIBUTE_NAME = "combine.children";
 }

--- a/src/main/java/org/atteo/xmlcombiner/XmlCombiner.java
+++ b/src/main/java/org/atteo/xmlcombiner/XmlCombiner.java
@@ -336,9 +336,27 @@ public class XmlCombiner {
 
 						Context dominantContext = dominantContexts.get(key).iterator().next();
 
-						Context combined = combine(recessiveContext, dominantContext);
-						if (combined != null) {
-							combined.addAsChildTo(resultElement);
+						CombineChildren recessiveCombineChildren = getCombineChildren(recessiveContext.getElement());
+						CombineChildren dominantCombineChildren = getCombineChildren(dominantContext.getElement());
+
+						if (recessiveCombineChildren == CombineChildren.ADD || dominantCombineChildren == CombineChildren.ADD) {
+							// Add both elements without merging
+							Context recessiveCopy = copyRecursively(recessiveContext);
+							recessiveCopy.addAsChildTo(resultElement);
+							if (recessiveCopy.getElement() != null) {
+								filter.postProcess(recessiveContext.getElement(), null, recessiveCopy.getElement());
+							}
+
+							Context dominantCopy = copyRecursively(dominantContext);
+							dominantCopy.addAsChildTo(resultElement);
+							if (dominantCopy.getElement() != null) {
+								filter.postProcess(null, dominantContext.getElement(), dominantCopy.getElement());
+							}
+						} else {
+							Context combined = combine(recessiveContext, dominantContext);
+							if (combined != null) {
+								combined.addAsChildTo(resultElement);
+							}
 						}
 					} else {
 						recessiveContext.addAsChildTo(resultElement);

--- a/src/test/java/org/atteo/xmlcombiner/XmlCombinerTest.java
+++ b/src/test/java/org/atteo/xmlcombiner/XmlCombinerTest.java
@@ -113,6 +113,94 @@ public class XmlCombinerTest {
 	}
 
 	@Test
+	public void addChildren() throws SAXException, IOException, ParserConfigurationException,
+			TransformerException {
+		// Test with ADD on recessive element
+		String recessive = "\n"
+				+ "<config>\n"
+				+ "    <service id='1' combine.children='ADD'>\n"
+				+ "        <parameter>parameter</parameter>\n"
+				+ "        <parameter2>parameter2</parameter2>\n"
+				+ "    </service>\n"
+				+ "</config>";
+		String dominant = "\n"
+				+ "<config>\n"
+				+ "    <service id='1'>\n"
+				+ "        <parameter>other value</parameter>\n"
+				+ "        <parameter3>parameter3</parameter3>\n"
+				+ "    </service>\n"
+				+ "</config>";
+		String result = "\n"
+				+ "<config>\n"
+				+ "    <service id='1'>\n"
+				+ "        <parameter>parameter</parameter>\n"
+				+ "        <parameter2>parameter2</parameter2>\n"
+				+ "    </service>\n"
+				+ "    <service id='1'>\n"
+				+ "        <parameter>other value</parameter>\n"
+				+ "        <parameter3>parameter3</parameter3>\n"
+				+ "    </service>\n"
+				+ "</config>";
+		assertThat(combineWithIdKey(recessive, dominant)).and(result).areSimilar();
+
+		// Test with ADD on dominant element
+		String recessive2 = "\n"
+				+ "<config>\n"
+				+ "    <service id='1'>\n"
+				+ "        <parameter>parameter</parameter>\n"
+				+ "        <parameter2>parameter2</parameter2>\n"
+				+ "    </service>\n"
+				+ "</config>";
+		String dominant2 = "\n"
+				+ "<config>\n"
+				+ "    <service id='1' combine.children='ADD'>\n"
+				+ "        <parameter>other value</parameter>\n"
+				+ "        <parameter3>parameter3</parameter3>\n"
+				+ "    </service>\n"
+				+ "</config>";
+		String result2 = "\n"
+				+ "<config>\n"
+				+ "    <service id='1'>\n"
+				+ "        <parameter>parameter</parameter>\n"
+				+ "        <parameter2>parameter2</parameter2>\n"
+				+ "    </service>\n"
+				+ "    <service id='1'>\n"
+				+ "        <parameter>other value</parameter>\n"
+				+ "        <parameter3>parameter3</parameter3>\n"
+				+ "    </service>\n"
+				+ "</config>";
+		assertThat(combineWithIdKey(recessive2, dominant2)).and(result2).areSimilar();
+
+		// Test with ADD on both elements
+		String recessive3 = "\n"
+				+ "<config>\n"
+				+ "    <service id='1' combine.children='ADD'>\n"
+				+ "        <parameter>parameter</parameter>\n"
+				+ "        <parameter2>parameter2</parameter2>\n"
+				+ "    </service>\n"
+				+ "</config>";
+		String dominant3 = "\n"
+				+ "<config>\n"
+				+ "    <service id='1' combine.children='ADD'>\n"
+				+ "        <parameter>other value</parameter>\n"
+				+ "        <parameter3>parameter3</parameter3>\n"
+				+ "    </service>\n"
+				+ "</config>";
+		String result3 = "\n"
+				+ "<config>\n"
+				+ "    <service id='1'>\n"
+				+ "        <parameter>parameter</parameter>\n"
+				+ "        <parameter2>parameter2</parameter2>\n"
+				+ "    </service>\n"
+				+ "    <service id='1'>\n"
+				+ "        <parameter>other value</parameter>\n"
+				+ "        <parameter3>parameter3</parameter3>\n"
+				+ "    </service>\n"
+				+ "</config>";
+		assertThat(combineWithIdKey(recessive3, dominant3)).and(result3).areSimilar();
+	}
+
+	@Test
 	public void commentPropagation() throws SAXException, IOException, ParserConfigurationException,
 			TransformerException {
 		String recessive = "\n"


### PR DESCRIPTION
Fix #11 

Another option is to use ['add'](https://oss.sonatype.org/service/local/repositories/releases/archive/org/atteo/xml-combiner/2.2/xml-combiner-2.2-javadoc.jar/!/org/atteo/xmlcombiner/CombineChildren.html#ADD) value for 'combine.children' attribute. When two matching elements have 'combine.children' set to 'add' (or at least one of them), both elements will appear in the final document without merging their content.

For example, combining:

```xml
<config>
    <service id='1' combine.children='ADD'>
        <parameter>parameter</parameter>
        <parameter2>parameter2</parameter2>
    </service>
</config>
```

with

```xml
<config>
    <service id='1'>
        <parameter>other value</parameter>
        <parameter3>parameter3</parameter3>
    </service>
</config>
```

results in

```xml
<config>
    <service id='1'>
        <parameter>parameter</parameter>
        <parameter2>parameter2</parameter2>
    </service>
    <service id='1'>
        <parameter>other value</parameter>
        <parameter3>parameter3</parameter3>
    </service>
</config>
```